### PR TITLE
Add homepage tool counter

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import TikTokView from '../components/TikTokView.astro';
 import { getCollection } from 'astro:content';
 
 const allTools = await getCollection('tools');
+const toolCount = allTools.length;
 
 const featuredTools = allTools.filter(t => t.data.featured);
 
@@ -105,6 +106,30 @@ const latestTools = pool.slice(0, 9);
         </div>
       </div>
     </section>
+
+    <section class="section census-section" aria-labelledby="town-census-title">
+      <div class="census-card">
+        <p class="census-kicker">Town census</p>
+        <div class="census-row">
+          <p
+            id="town-census-count"
+            class="census-count"
+            data-target={toolCount}
+            aria-live="polite"
+            aria-label={`${toolCount} tools in Tiny Tool Town`}
+          >
+            0
+          </p>
+          <div class="census-copy">
+            <h2 id="town-census-title">Tiny tools and counting</h2>
+            <p>
+              Every shop in town is a tiny open source project somebody cared enough to finish,
+              publish, and share.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
   </main>
 
   <!-- Floating button to launch Shorts mode -->
@@ -160,6 +185,11 @@ const latestTools = pool.slice(0, 9);
     margin-top: 2rem;
   }
 
+  .census-section {
+    margin-top: 2rem;
+    margin-bottom: 4rem;
+  }
+
   .manifesto-card {
     background: var(--color-bg-card);
     border: 1px solid var(--color-border);
@@ -168,6 +198,66 @@ const latestTools = pool.slice(0, 9);
     text-align: center;
     max-width: 700px;
     margin: 0 auto;
+  }
+
+  .census-card {
+    position: relative;
+    overflow: hidden;
+    background:
+      radial-gradient(circle at top left, color-mix(in srgb, var(--color-primary) 16%, transparent), transparent 42%),
+      radial-gradient(circle at bottom right, color-mix(in srgb, var(--color-accent) 18%, transparent), transparent 38%),
+      var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: 2rem;
+  }
+
+  .census-card::after {
+    content: '';
+    position: absolute;
+    inset: auto -10% -35% auto;
+    width: 220px;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--color-primary) 18%, transparent);
+    filter: blur(30px);
+    pointer-events: none;
+  }
+
+  .census-kicker {
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.72rem;
+    margin-bottom: 1rem;
+  }
+
+  .census-row {
+    display: grid;
+    grid-template-columns: minmax(0, 240px) minmax(0, 1fr);
+    gap: 1.5rem;
+    align-items: center;
+  }
+
+  .census-count {
+    margin: 0;
+    font-size: clamp(4rem, 12vw, 7rem);
+    line-height: 0.9;
+    font-weight: 900;
+    color: var(--color-primary);
+    text-shadow: 0 10px 30px color-mix(in srgb, var(--color-primary) 25%, transparent);
+  }
+
+  .census-copy h2 {
+    font-size: clamp(1.6rem, 3vw, 2.2rem);
+    margin-bottom: 0.75rem;
+  }
+
+  .census-copy p {
+    margin: 0;
+    color: var(--color-text-muted);
+    line-height: 1.7;
+    max-width: 44ch;
   }
 
   .manifesto-card h2 {
@@ -195,6 +285,18 @@ const latestTools = pool.slice(0, 9);
 
   @media (max-width: 640px) {
     .section-header { flex-direction: column; gap: 0.25rem; }
+    .census-card {
+      padding: 1.5rem;
+    }
+
+    .census-row {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+
+    .census-count {
+      font-size: clamp(3.25rem, 20vw, 5rem);
+    }
   }
 
   /* Floating Shorts Button */
@@ -238,6 +340,44 @@ const latestTools = pool.slice(0, 9);
 </style>
 
 <script>
+  const censusCount = document.getElementById('town-census-count');
+  if (censusCount instanceof HTMLElement) {
+    const target = Number(censusCount.dataset.target ?? '0');
+    const durationMs = 1600;
+    let hasAnimated = false;
+
+    const formatCount = (value) => new Intl.NumberFormat().format(value);
+
+    const animateCount = () => {
+      const startTime = performance.now();
+
+      const updateCount = (currentTime) => {
+        const progress = Math.min((currentTime - startTime) / durationMs, 1);
+        const easedProgress = 1 - Math.pow(1 - progress, 3);
+        const currentValue = Math.round(target * easedProgress);
+
+        censusCount.textContent = formatCount(currentValue);
+
+        if (progress < 1) {
+          requestAnimationFrame(updateCount);
+        }
+      };
+
+      requestAnimationFrame(updateCount);
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      const isVisible = entries.some((entry) => entry.isIntersecting);
+      if (!hasAnimated && isVisible) {
+        hasAnimated = true;
+        animateCount();
+        observer.disconnect();
+      }
+    }, { threshold: 0.4 });
+
+    observer.observe(censusCount);
+  }
+
   // Launch vertical shorts view when button is clicked
   const launchBtn = document.getElementById('launch-vertical-view');
   if (launchBtn) {


### PR DESCRIPTION
## Problem / Context
- The homepage already highlights featured and latest tools, but it does not show how large Tiny Tool Town has grown.
- The goal is to surface the current number of published tools without introducing a manually maintained value.

## What Changed
- Computed the total number of tools from the existing content collection in `src/pages/index.astro`.
- Added a new **Town census** section to the homepage that displays the total tool count.
- Added responsive styling for the census card so the layout works on both desktop and mobile.
- Added a scroll-triggered count-up animation so the number animates into place when the section enters the viewport.

## Implementation Details
- `toolCount` is derived from `allTools.length`, so the displayed total stays in sync with the collection automatically.
- The count is rendered with a `data-target` attribute, `aria-live="polite"`, and an `aria-label` so the final value is announced accessibly.
- A small inline script uses `Intl.NumberFormat`, `requestAnimationFrame`, and an ease-out curve to animate from `0` to the final count over ~1.6 seconds.
- `IntersectionObserver` is used with a one-time trigger so the animation starts only after the count becomes visible.
- The PR only changes `src/pages/index.astro`; there are no content, routing, or configuration updates in the commit diff.

## Testing / Verification
- `npm run build`
- `npm test`

## Excluded Unrelated Changes
- During local review, unrelated workspace changes were present in `src/data/star-counts.json` and `.vscode/`.
- Those files are not part of PR #12 and are not included in the commit diff for `feat/homepage-counter`.
